### PR TITLE
fix schedule talks row

### DIFF
--- a/components/schedule.module.css
+++ b/components/schedule.module.css
@@ -75,6 +75,7 @@
   .talks {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
   }
 
   .talks > div {


### PR DESCRIPTION
## Problem

Bug in schedule talks page in desktop, it was imposible to see all talks.

![IMAGE 2021-09-23 16:47:46](https://user-images.githubusercontent.com/32195484/134540458-b074039c-8c35-4342-8de1-63b6baa946b4.jpg)

## Fix

I added a flex-wrap in the talks div to adapt the content

![IMAGE 2021-09-23 16:50:27](https://user-images.githubusercontent.com/32195484/134540863-f599ad12-d411-4d40-8c92-fc975aba4824.jpg)

